### PR TITLE
Fixes the credits in the German translation

### DIFF
--- a/README.german.md
+++ b/README.german.md
@@ -23,5 +23,3 @@ Euer Beitrag
 Dies ist eine Gemeinschaftsleistung. Pull Requests sind willkommen.
 
 (Auch Beiträge zu Wortlaut und Stil sind willkommen.)
-
-Translation by Rebecca Stiebeiner

--- a/app/views/about.blade.php
+++ b/app/views/about.blade.php
@@ -39,7 +39,7 @@
     Arabic by <a href="https://github.com/badrchaouai">Badr Chaouai</a> and <a href="https://github.com/ibrasho">Ibrahim AshShohail</a><br>
     Dutch by <a href="https://github.com/wvdweij">Wijnand</a><br>
     French by <a href="https://github.com/tgalopin">Titouan Galopin</a> and <a href="https://github.com/aalaap">Aalaap</a><br>
-    German by <a href="https://github.com/janhohner">Jan Hohner</a> and <a href="https://github.com/philipp-mueller">Philipp Mueller </a><br>
+    German by <a href="https://www.xing.com/profile/Rebecca_Stiebeiner">Rebecca Stiebeiner</a>, <a href="https://github.com/janhohner">Jan Hohner</a> and <a href="https://github.com/philipp-mueller">Philipp Mueller </a><br>
     Hindi by <a href="https://github.com/vanimurarka">Vani Murarka</a><br>
     Italian by <a href="https://twitter.com/damko">Damiano Venturin</a><br>
     Brazilian Portuguese by <a href="https://github.com/antonioribeiro">Antonio Carlos Ribeiro</a><br>


### PR DESCRIPTION
Fixes the request in https://github.com/kayladnls/code-manifesto/commit/448cc4cce94637633152537412383dec3c25b6f8#commitcomment-7630529 and moves the mention of Rebecca (who translated the manifesto to German, I only pushed the changes for her) to the about page of the website.
