### PR TITLE
Remove unnecessary comma and clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In the effort to create such a place, we hold to these values:
 4. **We are resources for the future.** As an extension of #3, share what you know. Make yourself a resource to help those that come after you.
 5. **Respect defines us.** Treat others as you wish to be treated. Make your discussions, criticisms and debates from a position of respectfulness. Ask yourself, is it true? Is it necessary? Is it constructive? Anything less is unacceptable.
 6. **Reactions require grace.** Angry responses are valid, but abusive language and vindictive actions are toxic. When something happens that offends you, handle it assertively, but be respectful. Escalate reasonably, and try to allow the offender an opportunity to explain themselves, and possibly correct the issue.
-7. **Opinions are just that: opinions.** Each and every one of us, due to our background and upbringing, have varying opinions. The fact of the matter, is that is perfectly acceptable. Remember this: if you respect your own opinions, you should respect the opinions of others.
+7. **Opinions are just that: opinions.** Each and every one of us, due to our background and upbringing, have varying opinions. The is that is perfectly acceptable. Remember this: if you respect your own opinions, you should respect the opinions of others.
 8. **To err is human.** You might not intend it, but mistakes do happen and contribute to build experience. Tolerate honest mistakes, and don't hesitate to apologize if you make one yourself.
 
 How to contribute

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In the effort to create such a place, we hold to these values:
 4. **We are resources for the future.** As an extension of #3, share what you know. Make yourself a resource to help those that come after you.
 5. **Respect defines us.** Treat others as you wish to be treated. Make your discussions, criticisms and debates from a position of respectfulness. Ask yourself, is it true? Is it necessary? Is it constructive? Anything less is unacceptable.
 6. **Reactions require grace.** Angry responses are valid, but abusive language and vindictive actions are toxic. When something happens that offends you, handle it assertively, but be respectful. Escalate reasonably, and try to allow the offender an opportunity to explain themselves, and possibly correct the issue.
-7. **Opinions are just that: opinions.** Each and every one of us, due to our background and upbringing, have varying opinions. The is that is perfectly acceptable. Remember this: if you respect your own opinions, you should respect the opinions of others.
+7. **Opinions are just that: opinions.** Each and every one of us, due to our background and upbringing, have varying opinions. That is perfectly acceptable. Remember this: if you respect your own opinions, you should respect the opinions of others.
 8. **To err is human.** You might not intend it, but mistakes do happen and contribute to build experience. Tolerate honest mistakes, and don't hesitate to apologize if you make one yourself.
 
 How to contribute


### PR DESCRIPTION
The comma in the current text is unnecessary and extraneous. Removing it, the sentence feels rather wordy.  I therefore propose shortening it to a simple declarative statement of fact, which has the same meaning as the earlier text.